### PR TITLE
Ensure AiHubMix responses contain image data

### DIFF
--- a/lib/job-processor.ts
+++ b/lib/job-processor.ts
@@ -57,6 +57,66 @@ const downloadOriginalImage = async (client: SupabaseServiceClient, path: string
   return Buffer.from(arrayBuffer);
 };
 
+type AihubmixContentPart = {
+  inline_data?: { data?: string; mime_type?: string };
+  content?: AihubmixContentPart[];
+  image_base64?: string;
+  b64_json?: string;
+  data?: string;
+  mime_type?: string;
+  type?: string;
+};
+
+const flattenParts = (value: unknown): AihubmixContentPart[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const result: AihubmixContentPart[] = [];
+  const queue: AihubmixContentPart[] = [...(value as AihubmixContentPart[])];
+
+  while (queue.length > 0) {
+    const part = queue.shift();
+    if (!part || typeof part !== "object") {
+      continue;
+    }
+
+    result.push(part);
+
+    if (Array.isArray(part.content)) {
+      queue.push(...part.content);
+    }
+  }
+
+  return result;
+};
+
+const extractImageData = (message: any) => {
+  const candidates: AihubmixContentPart[] = [
+    ...flattenParts(message?.multi_mod_content),
+    ...flattenParts(message?.multi_modal_content),
+    ...flattenParts(message?.content),
+  ];
+
+  for (const part of candidates) {
+    const inlineData = part.inline_data;
+    const base64Data =
+      inlineData?.data ?? part.image_base64 ?? part.b64_json ?? part.data;
+
+    if (typeof base64Data === "string" && base64Data.trim()) {
+      const mimeTypeCandidate = inlineData?.mime_type ?? part.mime_type ?? part.type;
+      const mimeType =
+        typeof mimeTypeCandidate === "string" && mimeTypeCandidate.startsWith("image/")
+          ? mimeTypeCandidate
+          : "image/png";
+
+      return { base64Data, mimeType };
+    }
+  }
+
+  return null;
+};
+
 const callAihubmix = async (base64Image: string): Promise<{ buffer: Buffer; mimeType: string }> => {
   if (!API_KEY) {
     throw new Error("AIHUBMIX_API_KEY not configured");
@@ -65,6 +125,15 @@ const callAihubmix = async (base64Image: string): Promise<{ buffer: Buffer; mime
   const payload = {
     model: PRODUCT_MODEL,
     messages: [
+      {
+        role: "system",
+        content: [
+          {
+            type: "text",
+            text: "You must return exactly one enhanced product image as inline base64 data. Do not include any text or additional responses.",
+          },
+        ],
+      },
       {
         role: "user",
         content: [
@@ -79,8 +148,8 @@ const callAihubmix = async (base64Image: string): Promise<{ buffer: Buffer; mime
         ],
       },
     ],
-    modalities: ["text", "image"],
-    temperature: 0.7,
+    modalities: ["image"],
+    temperature: 0.2,
   };
 
   const response = await fetch(`${API_BASE_URL}/chat/completions`, {
@@ -98,15 +167,14 @@ const callAihubmix = async (base64Image: string): Promise<{ buffer: Buffer; mime
   }
 
   const json = await response.json();
-  const multiContent = json?.choices?.[0]?.message?.multi_mod_content ?? [];
-  const imagePart = multiContent.find((part: any) => part?.inline_data?.data);
+  const imageData = extractImageData(json?.choices?.[0]?.message ?? {});
 
-  if (!imagePart?.inline_data?.data) {
-    throw new Error("Please try again");
+  if (!imageData) {
+    throw new Error("Model did not return image data");
   }
 
-  const mimeType: string = imagePart.inline_data.mime_type ?? "image/png";
-  const buffer = Buffer.from(imagePart.inline_data.data, "base64");
+  const buffer = Buffer.from(imageData.base64Data, "base64");
+  const mimeType: string = imageData.mimeType ?? "image/png";
   return { buffer, mimeType };
 };
 


### PR DESCRIPTION
## Summary
- add strict parsing to extract inline image data from AiHubMix responses and report explicit errors when missing
- request image-only outputs with a system prompt and image-only modality to avoid text replies
- lower generation temperature to reduce unexpected non-image responses

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0dc1cb488325b5098f13dbbae456