### PR TITLE
Fix job processor syntax error

### DIFF
--- a/lib/job-processor.ts
+++ b/lib/job-processor.ts
@@ -245,20 +245,11 @@ export async function processImageJob(
   if (updateError || !updatedJob) {
     throw new Error(updateError?.message ?? "Failed to update job record");
   }
-  const { error: incrementError } = await (client.rpc("increment_processed_total", { step: 1 }) as any);
-  if (incrementError) {
-    console.error("increment_processed_total error", incrementError);
-  }
-
-  return updatedJob as ImageJobRow;
-};
-
-  if (incrementError) {
-    console.error("increment_processed_total error", incrementError);
-  }
-
-  // Call without explicit args so the RPC works even if Supabase types are out of date.
-  const { error: incrementError } = await (client.rpc("increment_processed_total") as any);
+  // Cast arguments to any to avoid type mismatches if Supabase types are out of date.
+  const { error: incrementError } = await (client.rpc(
+    "increment_processed_total",
+    { step: 1 } as any
+  ) as any);
   if (incrementError) {
     console.error("increment_processed_total error", incrementError);
   }


### PR DESCRIPTION
## Summary
- remove duplicated return and RPC logic at the end of `processImageJob` so the function has a single closing block
- call the `increment_processed_total` RPC with a typed cast and document the reason to avoid Supabase type drift issues

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0170c4fe48325a4b7f5f542aa50ef