### PR TITLE
Fix duplicate increment error variable

### DIFF
--- a/lib/job-processor.ts
+++ b/lib/job-processor.ts
@@ -255,9 +255,9 @@ export async function processImageJob(
   }
 
   // Call without explicit args so the RPC works even if Supabase types are out of date.
-  const { error: incrementError } = await (client.rpc("increment_processed_total") as any);
-  if (incrementError) {
-    console.error("increment_processed_total error", incrementError);
+  const { error: fallbackIncrementError } = await (client.rpc("increment_processed_total") as any);
+  if (fallbackIncrementError) {
+    console.error("increment_processed_total error", fallbackIncrementError);
   }
 
   return updatedJob as ImageJobRow;


### PR DESCRIPTION
## Summary
- avoid redeclaring the `incrementError` constant in the job processor
- log fallback RPC errors using a distinct variable name

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d021531d208325ba31869b78dcc790