### PR TITLE
style: refresh white liquid glass aesthetic

### DIFF
--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -7,13 +7,243 @@
 }
 
 body {
-  @apply bg-surface-muted text-slate-900 antialiased;
+  @apply min-h-screen antialiased text-slate-900;
+  background:
+    radial-gradient(120% 140% at 15% 10%, rgba(147, 197, 253, 0.22), transparent 55%),
+    radial-gradient(110% 130% at 85% 5%, rgba(196, 181, 253, 0.22), transparent 60%),
+    radial-gradient(140% 120% at 20% 90%, rgba(125, 211, 252, 0.18), transparent 65%),
+    linear-gradient(160deg, #f8fafc 0%, #ffffff 45%, #eef2ff 100%);
+  background-color: #ffffff;
+  background-attachment: fixed;
+  position: relative;
 }
 
-.gradient-card {
-  @apply bg-gradient-to-br from-white/95 via-slate-50 to-slate-100;
+.backdrop-blur-xl {
+  -webkit-backdrop-filter: blur(24px);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(circle at 55% 18%, rgba(255, 255, 255, 0.65), transparent 62%),
+    radial-gradient(circle at 18% 78%, rgba(191, 219, 254, 0.35), transparent 70%),
+    radial-gradient(circle at 82% 72%, rgba(221, 214, 254, 0.28), transparent 72%);
+  opacity: 0.85;
+  pointer-events: none;
+  z-index: -1;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.35) 1px, transparent 1px);
+  background-size: 88px 88px;
+  mix-blend-mode: soft-light;
+  opacity: 0.55;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.glass-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.82), rgba(248, 250, 252, 0.5));
+  box-shadow:
+    0 30px 70px -45px rgba(15, 23, 42, 0.25),
+    0 1px 0 rgba(255, 255, 255, 0.85) inset,
+    0 0 30px rgba(255, 255, 255, 0.45) inset;
+  backdrop-filter: blur(30px);
+  -webkit-backdrop-filter: blur(30px);
+  transition: border-color 240ms ease, box-shadow 240ms ease, transform 240ms ease;
+}
+
+.glass-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.35));
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.glass-card::after {
+  content: "";
+  position: absolute;
+  top: -35%;
+  right: -12%;
+  width: 55%;
+  height: 80%;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.85) 0%, rgba(255, 255, 255, 0) 62%);
+  filter: blur(18px);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.glass-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.glass-card:hover {
+  border-color: rgba(255, 255, 255, 0.78);
+  box-shadow:
+    0 36px 85px -48px rgba(15, 23, 42, 0.35),
+    0 1px 0 rgba(255, 255, 255, 0.95) inset,
+    0 0 36px rgba(255, 255, 255, 0.55) inset;
 }
 
 .action-button {
-  @apply flex flex-col items-center justify-center gap-2 rounded-2xl px-4 py-6 text-sm font-medium shadow-card transition;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 1.75rem;
+  padding: 1.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: 1px solid rgba(255, 255, 255, 0.75);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.82), rgba(241, 245, 249, 0.45));
+  color: #0f172a;
+  box-shadow:
+    0 26px 60px -38px rgba(15, 23, 42, 0.28),
+    0 1px 0 rgba(255, 255, 255, 0.75) inset;
+  backdrop-filter: blur(26px);
+  -webkit-backdrop-filter: blur(26px);
+  transition: transform 220ms ease, box-shadow 220ms ease, border-color 220ms ease;
+}
+
+.action-button::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.08));
+  opacity: 0.75;
+  pointer-events: none;
+  transition: opacity 200ms ease;
+}
+
+.action-button:hover:not(:disabled) {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.9);
+  box-shadow:
+    0 32px 70px -40px rgba(15, 23, 42, 0.32),
+    0 1px 0 rgba(255, 255, 255, 0.85) inset;
+}
+
+.action-button:hover:not(:disabled)::after {
+  opacity: 0.92;
+}
+
+.action-button:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 3px rgba(191, 219, 254, 0.45),
+    0 30px 70px -40px rgba(15, 23, 42, 0.34);
+}
+
+.action-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: 0 14px 36px -32px rgba(15, 23, 42, 0.32);
+}
+
+.action-button > * {
+  position: relative;
+  z-index: 1;
+}
+
+.action-button--primary {
+  color: #0f172a;
+  border-color: rgba(147, 197, 253, 0.8);
+  background: linear-gradient(140deg, rgba(191, 219, 254, 0.82), rgba(125, 211, 252, 0.65));
+  box-shadow:
+    0 32px 70px -40px rgba(59, 130, 246, 0.35),
+    0 1px 0 rgba(255, 255, 255, 0.9) inset;
+}
+
+.action-button--emerald {
+  color: #0f172a;
+  border-color: rgba(167, 243, 208, 0.75);
+  background: linear-gradient(140deg, rgba(209, 250, 229, 0.82), rgba(167, 243, 208, 0.6));
+  box-shadow:
+    0 32px 70px -40px rgba(16, 185, 129, 0.32),
+    0 1px 0 rgba(255, 255, 255, 0.9) inset;
+}
+
+.action-button--violet {
+  color: #1f2937;
+  border-color: rgba(221, 214, 254, 0.82);
+  background: linear-gradient(140deg, rgba(237, 233, 254, 0.85), rgba(221, 214, 254, 0.62));
+  box-shadow:
+    0 32px 70px -40px rgba(139, 92, 246, 0.32),
+    0 1px 0 rgba(255, 255, 255, 0.9) inset;
+}
+
+.action-button--rose {
+  color: #1f2937;
+  border-color: rgba(254, 215, 226, 0.78);
+  background: linear-gradient(140deg, rgba(254, 205, 211, 0.82), rgba(253, 164, 175, 0.58));
+  box-shadow:
+    0 32px 70px -40px rgba(244, 63, 94, 0.3),
+    0 1px 0 rgba(255, 255, 255, 0.9) inset;
+}
+
+.toolbar {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  border-radius: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  background: rgba(255, 255, 255, 0.65);
+  box-shadow:
+    0 32px 75px -48px rgba(15, 23, 42, 0.28),
+    0 1px 0 rgba(255, 255, 255, 0.75) inset,
+    0 0 28px rgba(255, 255, 255, 0.42) inset;
+  padding: 1.5rem;
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+}
+
+.toolbar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 22% 25%, rgba(255, 255, 255, 0.85), transparent 55%),
+    radial-gradient(circle at 85% 10%, rgba(191, 219, 254, 0.4), transparent 62%),
+    radial-gradient(circle at 10% 100%, rgba(254, 205, 211, 0.28), transparent 70%);
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.toolbar > * {
+  position: relative;
+  z-index: 1;
+}
+
+@supports (-apple-visual-effect: -apple-system-glass-material) {
+  .toolbar {
+    background: transparent;
+    -apple-visual-effect: -apple-system-glass-material;
+  }
+
+  .glass-card {
+    background: transparent;
+    -apple-visual-effect: -apple-system-glass-material;
+  }
+
+  .action-button {
+    -apple-visual-effect: -apple-system-glass-material;
+  }
 }

--- a/components/actions/action-grid.tsx
+++ b/components/actions/action-grid.tsx
@@ -43,50 +43,56 @@ export const ActionGrid = () => {
     <>
       <input id="camera-input" type="file" accept="image/*" capture="environment" className="hidden" onChange={onChange} />
       <input id="library-input" type="file" accept="image/*" className="hidden" onChange={onChange} />
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-6">
-        <button className="action-button bg-gradient-to-br from-blue-500 to-blue-600 text-white" onClick={triggerCamera} disabled={isPreparing || isSubmitting}>
-          <Camera className="h-6 w-6" />
-          <span>{t('takePhoto')}</span>
-        </button>
-        <button className="action-button bg-white text-slate-700 hover:bg-slate-100" onClick={triggerLibrary} disabled={isPreparing || isSubmitting}>
-          <ImagePlus className="h-6 w-6 text-brand-primary" />
-          <span>{t('fromAlbum')}</span>
-        </button>
-        <button
-          className="action-button bg-gradient-to-br from-emerald-500 to-emerald-600 text-white disabled:from-slate-400 disabled:to-slate-500"
-          onClick={() => startJob("enhance", supabase, { costCredits: 0 })}
-          disabled={isSubmitting || (!currentJob?.localFile && !currentJob?.originalStoragePath)}
-        >
-          {isSubmitting ? <Loader2 className="h-6 w-6 animate-spin" /> : <Sparkles className="h-6 w-6" />}
-          <span>{isSubmitting ? t('uploading') : t('enhanceQuality')}</span>
-        </button>
-        <button
-          className="action-button bg-gradient-to-br from-purple-500 to-purple-600 text-white disabled:from-slate-400 disabled:to-slate-500"
-          onClick={() => startJob("product", supabase, { costCredits: 600 })}
-          disabled={isSubmitting || (!currentJob?.localFile && !currentJob?.originalStoragePath)}
-        >
-          {isSubmitting ? <Loader2 className="h-6 w-6 animate-spin" /> : <Package className="h-6 w-6" />}
-          <span>{isSubmitting ? t('processing') : t('generateProductPhoto')}</span>
-        </button>
-        <button
-          className="action-button bg-white text-slate-700 hover:bg-slate-100"
-          onClick={() => {
-            void share();
-          }}
-          disabled={isSubmitting}
-        >
-          <Share2 className="h-6 w-6 text-brand-primary" />
-          <span>{t('share')}</span>
-        </button>
-        <button
-          className="action-button bg-white text-slate-700 hover:bg-slate-100"
-          onClick={download}
-          disabled={!currentJob?.processedImageUrl}
-        >
-          <Download className="h-6 w-6 text-brand-primary" />
-          <span>{t('downloadImage')}</span>
-        </button>
-      </div>
+      <section className="toolbar">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-6">
+          <button
+            className="action-button action-button--primary"
+            onClick={triggerCamera}
+            disabled={isPreparing || isSubmitting}
+          >
+            <Camera className="h-6 w-6" />
+            <span>{t('takePhoto')}</span>
+          </button>
+          <button className="action-button" onClick={triggerLibrary} disabled={isPreparing || isSubmitting}>
+            <ImagePlus className="h-6 w-6 text-brand-primary" />
+            <span>{t('fromAlbum')}</span>
+          </button>
+          <button
+            className="action-button action-button--emerald"
+            onClick={() => startJob("enhance", supabase, { costCredits: 0 })}
+            disabled={isSubmitting || (!currentJob?.localFile && !currentJob?.originalStoragePath)}
+          >
+            {isSubmitting ? <Loader2 className="h-6 w-6 animate-spin" /> : <Sparkles className="h-6 w-6" />}
+            <span>{isSubmitting ? t('uploading') : t('enhanceQuality')}</span>
+          </button>
+          <button
+            className="action-button action-button--violet"
+            onClick={() => startJob("product", supabase, { costCredits: 600 })}
+            disabled={isSubmitting || (!currentJob?.localFile && !currentJob?.originalStoragePath)}
+          >
+            {isSubmitting ? <Loader2 className="h-6 w-6 animate-spin" /> : <Package className="h-6 w-6" />}
+            <span>{isSubmitting ? t('processing') : t('generateProductPhoto')}</span>
+          </button>
+          <button
+            className="action-button action-button--rose"
+            onClick={() => {
+              void share();
+            }}
+            disabled={isSubmitting}
+          >
+            <Share2 className="h-6 w-6" />
+            <span>{t('share')}</span>
+          </button>
+          <button
+            className="action-button"
+            onClick={download}
+            disabled={!currentJob?.processedImageUrl}
+          >
+            <Download className="h-6 w-6 text-brand-primary" />
+            <span>{t('downloadImage')}</span>
+          </button>
+        </div>
+      </section>
     </>
   );
 };

--- a/components/actions/purchase-credits-button.tsx
+++ b/components/actions/purchase-credits-button.tsx
@@ -25,7 +25,7 @@ export const PurchaseCreditsButton = () => {
   return (
     <button
       onClick={handlePurchase}
-      className="rounded-full bg-gradient-to-r from-blue-500 to-blue-600 px-5 py-3 text-sm font-semibold text-white shadow-card transition hover:from-blue-600 hover:to-blue-700"
+      className="relative flex items-center justify-center gap-2 rounded-full border border-white/80 bg-gradient-to-r from-sky-100/85 via-sky-200/70 to-indigo-200/65 px-5 py-3 text-sm font-semibold text-slate-800 shadow-[0_28px_62px_-34px_rgba(125,211,252,0.6)] backdrop-blur-xl transition hover:-translate-y-0.5 hover:shadow-[0_32px_70px_-32px_rgba(125,211,252,0.65)] disabled:cursor-not-allowed disabled:opacity-70"
       disabled={loading}
     >
       {loading ? "Pending" : "Buy Credit"}

--- a/components/auth/auth-gate.tsx
+++ b/components/auth/auth-gate.tsx
@@ -13,18 +13,34 @@ export const AuthGate = ({ children }: { children: React.ReactNode }) => {
 
   if (!mounted) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-surface-muted">
-        <p className="text-sm text-slate-500">Loading…</p>
+      <div className="relative flex min-h-screen items-center justify-center overflow-hidden">
+        <div className="pointer-events-none absolute inset-0 -z-10">
+          <div className="absolute inset-0 bg-[radial-gradient(140%_140%_at_15%_5%,rgba(191,219,254,0.32),transparent_58%),radial-gradient(120%_140%_at_85%_0%,rgba(221,214,254,0.28),transparent_60%),linear-gradient(165deg,rgba(248,250,252,0.95)_0%,rgba(255,255,255,0.92)_48%,rgba(238,242,255,0.94)_100%)]" />
+          <div className="absolute inset-0 bg-white/35 mix-blend-soft-light" />
+        </div>
+        <div className="glass-card px-8 py-5 text-center text-slate-800">
+          <p className="text-sm font-medium">Loading…</p>
+        </div>
       </div>
     );
   }
 
   if (!session) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-surface-muted px-6 text-center">
-        <h1 className="text-2xl font-semibold text-slate-800">Login to continue using EasyPic</h1>
-        <p className="max-w-sm text-sm text-slate-500">Use email magic link or Google one-click login to unlock credit sync, history, and cloud processing.</p>
-        <SignInButton />
+      <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-6 py-16 text-center">
+        <div className="pointer-events-none absolute inset-0 -z-10">
+          <div className="absolute inset-0 bg-[radial-gradient(150%_150%_at_8%_0%,rgba(191,219,254,0.32),transparent_58%),radial-gradient(130%_140%_at_92%_5%,rgba(221,214,254,0.3),transparent_65%),radial-gradient(160%_140%_at_20%_95%,rgba(254,215,226,0.25),transparent_72%),linear-gradient(165deg,rgba(248,250,252,0.96)_0%,rgba(255,255,255,0.92)_48%,rgba(238,242,255,0.94)_100%)]" />
+          <div className="absolute inset-0 bg-white/35 mix-blend-soft-light" />
+        </div>
+        <div className="glass-card w-full max-w-xl px-10 py-12 text-center text-slate-800">
+          <h1 className="text-3xl font-semibold tracking-tight text-slate-800">Login to continue using EasyPic</h1>
+          <p className="mx-auto mt-3 max-w-md text-sm text-slate-600">
+            Use email magic link or Google one-click login to unlock credit sync, history, and cloud processing.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <SignInButton />
+          </div>
+        </div>
       </div>
     );
   }

--- a/components/auth/sign-in-button.tsx
+++ b/components/auth/sign-in-button.tsx
@@ -58,21 +58,21 @@ export const SignInButton = () => {
   };
 
   return (
-    <div className="w-full max-w-sm space-y-6 text-left">
+    <div className="w-full max-w-sm space-y-6 text-left text-slate-800">
       <form onSubmit={handleEmail} className="space-y-3">
-        <label className="block text-sm font-medium text-slate-700">Email Login</label>
+        <label className="block text-sm font-medium tracking-wide text-slate-600">Email Login</label>
         <div className="flex items-center gap-3">
           <input
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
-            className="flex-1 rounded-full border border-slate-200 px-4 py-3 text-sm shadow-inner focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+            className="flex-1 rounded-full border border-white/70 bg-white/70 px-5 py-3 text-sm text-slate-800 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)] backdrop-blur-xl placeholder:text-slate-500 focus:border-sky-200 focus:outline-none focus:ring-2 focus:ring-sky-100/80"
             placeholder="you@example.com"
             required
           />
           <button
             type="submit"
-            className="flex items-center gap-2 rounded-full bg-brand-primary px-4 py-2 text-sm font-medium text-white shadow-card transition hover:bg-brand-accent disabled:bg-slate-400"
+            className="flex items-center gap-2 rounded-full border border-white/80 bg-gradient-to-r from-sky-100/80 via-sky-200/70 to-sky-300/70 px-5 py-3 text-sm font-semibold text-slate-800 shadow-[0_24px_50px_-32px_rgba(125,211,252,0.65)] backdrop-blur-xl transition hover:-translate-y-0.5 hover:shadow-[0_28px_60px_-30px_rgba(125,211,252,0.7)] disabled:cursor-not-allowed disabled:opacity-70"
             disabled={status !== "idle"}
           >
             <Mail className="h-4 w-4" />
@@ -82,15 +82,15 @@ export const SignInButton = () => {
       </form>
 
       <div className="relative">
-        <span className="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-xs uppercase tracking-wide text-slate-400">
+        <span className="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-xs uppercase tracking-[0.35em] text-slate-500">
           OR
         </span>
-        <div className="border-t border-dashed border-slate-200" />
+        <div className="border-t border-dashed border-white/40" />
       </div>
 
       <button
         onClick={handleGoogle}
-        className="flex w-full items-center justify-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-700 shadow-card transition hover:bg-slate-50 disabled:bg-slate-100"
+        className="flex w-full items-center justify-center gap-2 rounded-full border border-white/80 bg-white/75 px-5 py-3 text-sm font-semibold text-slate-700 shadow-[0_24px_50px_-32px_rgba(15,23,42,0.28)] backdrop-blur-xl transition hover:-translate-y-0.5 hover:bg-white/85 disabled:cursor-not-allowed disabled:opacity-70"
         disabled={status !== "idle"}
       >
         <LogIn className="h-4 w-4 text-brand-primary" />

--- a/components/header/header-card.tsx
+++ b/components/header/header-card.tsx
@@ -17,11 +17,15 @@ export const HeaderCard = () => {
   const displayName = profile?.display_name ?? session?.user.email ?? t('defaultUser');
 
   return (
-    <section className="gradient-card rounded-card p-6 shadow-soft">
+    <section className="glass-card p-6 text-slate-900">
       <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-start gap-3">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-brand-primary/10">
-            {isLoggedIn ? <LogIn className="h-6 w-6 text-brand-primary" /> : <LogOut className="h-6 w-6 text-slate-500" />}
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/60 bg-white/60 text-brand-primary shadow-[0_18px_30px_-22px_rgba(37,99,235,0.7)]">
+            {isLoggedIn ? (
+              <LogIn className="h-6 w-6" />
+            ) : (
+              <LogOut className="h-6 w-6 text-slate-500" />
+            )}
           </div>
           <div className="space-y-2">
             <h2 className="text-lg font-semibold text-slate-800">
@@ -48,10 +52,10 @@ export const HeaderCard = () => {
           {isLoggedIn && <PurchaseCreditsButton />}
           <button
             onClick={openSettingsDrawer}
-            className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-200 text-slate-600 shadow-card transition hover:bg-slate-300"
+            className="group relative flex h-12 w-12 items-center justify-center rounded-2xl border border-white/50 bg-white/40 text-slate-600 transition hover:-translate-y-0.5 hover:bg-white/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
             aria-label={t('settings')}
           >
-            <Settings className="h-5 w-5" />
+            <Settings className="h-5 w-5 transition group-hover:rotate-12" />
           </button>
         </div>
       </div>

--- a/components/invite/invite-cta.tsx
+++ b/components/invite/invite-cta.tsx
@@ -62,14 +62,14 @@ export const InviteCTA = () => {
   };
 
   return (
-    <section className="rounded-card bg-white p-6 shadow-card">
+    <section className="glass-card p-6 text-slate-900">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div className="flex items-start gap-3">
           <button
             type="button"
             onClick={handleGiftClick}
             disabled={redeeming}
-            className="mt-1 flex h-10 w-10 items-center justify-center rounded-full bg-rose-100 text-rose-500 transition hover:bg-rose-200 disabled:cursor-not-allowed disabled:opacity-60"
+            className="mt-1 flex h-10 w-10 items-center justify-center rounded-2xl border border-white/75 bg-white/70 text-rose-500 shadow-[0_20px_44px_-30px_rgba(244,114,182,0.45)] transition hover:-translate-y-0.5 hover:bg-white/80 disabled:cursor-not-allowed disabled:opacity-60"
             title={t('prompt')}
             aria-label={t('prompt')}
           >
@@ -86,11 +86,11 @@ export const InviteCTA = () => {
           <button
             onClick={handleShareClick}
             disabled={sharing}
-            className="rounded-xl bg-gradient-to-r from-rose-500 to-rose-600 px-5 py-3 text-sm font-semibold text-white shadow-card disabled:opacity-70"
+            className="relative flex items-center justify-center gap-2 rounded-2xl border border-white/80 bg-gradient-to-r from-rose-100/85 via-rose-200/70 to-rose-300/65 px-5 py-3 text-sm font-semibold text-slate-800 shadow-[0_30px_70px_-36px_rgba(244,114,182,0.5)] backdrop-blur-xl transition hover:-translate-y-0.5 hover:shadow-[0_34px_78px_-34px_rgba(244,114,182,0.55)] disabled:cursor-not-allowed disabled:opacity-70"
           >
             {sharing ? t('sharing') : t('shareButton')}
           </button>
-          <p className="text-[11px] text-slate-400">{t('shareHint', { link: SHARE_APP_LINK })}</p>
+          <p className="text-[11px] text-slate-500">{t('shareHint', { link: SHARE_APP_LINK })}</p>
           {shareMessage && <p className="text-[11px] text-rose-500">{shareMessage}</p>}
         </div>
       </div>

--- a/components/jobs/job-history-strip.tsx
+++ b/components/jobs/job-history-strip.tsx
@@ -12,14 +12,14 @@ export const JobHistoryStrip = () => {
     <section className="space-y-3">
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold text-slate-700">{t('title')}</h3>
-        <span className="text-xs text-slate-400">{t('limitNotice')}</span>
+        <span className="text-xs text-slate-500">{t('limitNotice')}</span>
       </div>
       <div className="flex gap-3 overflow-x-auto pb-2">
         {recentJobs.map((job) => (
           <button
             key={job.id}
             onClick={() => openJob(job.id)}
-            className="flex w-36 flex-col gap-2 rounded-2xl bg-white p-3 text-left shadow-card transition hover:-translate-y-1"
+            className="group relative flex w-36 flex-col gap-2 rounded-2xl border border-white/75 bg-white/70 p-3 text-left text-slate-800 shadow-[0_24px_52px_-34px_rgba(15,23,42,0.28)] backdrop-blur-xl transition hover:-translate-y-1 hover:border-white/85 hover:bg-white/80"
           >
             {job.thumbnailUrl ? (
               <Image
@@ -27,14 +27,14 @@ export const JobHistoryStrip = () => {
                 alt={t('historyAlt')}
                 width={144}
                 height={96}
-                className="h-24 w-full rounded-xl object-cover"
+                className="h-24 w-full rounded-xl border border-white/70 object-cover shadow-[0_16px_38px_-26px_rgba(15,23,42,0.28)]"
               />
             ) : (
-              <div className="flex h-24 items-center justify-center rounded-xl bg-slate-100 text-xs text-slate-400">
+              <div className="flex h-24 items-center justify-center rounded-xl border border-dashed border-white/70 bg-white/60 text-xs text-slate-500 backdrop-blur-xl">
                 {t('noPreview')}
               </div>
             )}
-            <div className="text-xs text-slate-500">
+            <div className="text-xs text-slate-600">
               <p className="font-semibold text-slate-700">#{job.displayId ?? job.id.slice(0, 6)}</p>
               <p>{job.state === "done" ? t('statusDone') : job.state === "failed" ? t('statusFailed') : t('statusInProgress')}</p>
             </div>

--- a/components/layout/dashboard-layout.tsx
+++ b/components/layout/dashboard-layout.tsx
@@ -2,7 +2,11 @@
 
 export const DashboardLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="min-h-screen bg-surface-muted">
+    <div className="relative min-h-screen overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-[radial-gradient(140%_140%_at_10%_0%,rgba(191,219,254,0.32),transparent_60%),radial-gradient(140%_140%_at_90%_-5%,rgba(221,214,254,0.28),transparent_65%),radial-gradient(160%_140%_at_20%_100%,rgba(125,211,252,0.25),transparent_70%),linear-gradient(165deg,rgba(248,250,252,0.95)_0%,rgba(255,255,255,0.9)_48%,rgba(238,242,255,0.92)_100%)]" />
+        <div className="absolute inset-0 bg-white/30 mix-blend-soft-light" />
+      </div>
       <div className="mx-auto w-full max-w-6xl pb-24 pt-safe-top">{children}</div>
     </div>
   );

--- a/components/panels/image-panels.tsx
+++ b/components/panels/image-panels.tsx
@@ -22,9 +22,9 @@ const Panel = ({
   zoomText: string;
   onSecretClick?: () => void;
 }) => (
-  <div className="rounded-card bg-white p-5 shadow-card">
+  <div className="glass-card p-5 text-slate-900">
     <div className="mb-4 flex items-center gap-2">
-      <div className="flex h-9 w-9 items-center justify-center rounded-full bg-brand-primary/10 text-brand-primary">{icon}</div>
+      <div className="flex h-9 w-9 items-center justify-center rounded-2xl border border-white/75 bg-white/75 text-brand-primary shadow-[0_16px_34px_-24px_rgba(59,130,246,0.35)]">{icon}</div>
       <h3 className="text-sm font-semibold text-slate-700">{title}</h3>
     </div>
     {imageUrl ? (
@@ -33,7 +33,7 @@ const Panel = ({
           onSecretClick?.();
           openViewer(imageUrl);
         }}
-        className="group relative block overflow-hidden rounded-2xl bg-slate-100 transition hover:shadow-soft"
+        className="group relative block overflow-hidden rounded-2xl border border-white/75 bg-white/70 shadow-[0_24px_55px_-34px_rgba(15,23,42,0.26)] backdrop-blur-xl transition hover:-translate-y-1 hover:border-white/85 hover:bg-white/80 hover:shadow-[0_30px_65px_-36px_rgba(15,23,42,0.3)]"
       >
         <Image
           src={imageUrl}
@@ -43,14 +43,14 @@ const Panel = ({
           className="mx-auto block h-full w-full rounded-2xl object-contain"
           sizes="(min-width: 1024px) 50vw, 100vw"
         />
-        <span className="absolute bottom-3 right-3 rounded-full bg-black/50 px-3 py-1 text-xs text-white opacity-0 transition group-hover:opacity-100">
+        <span className="absolute bottom-3 right-3 rounded-full border border-white/70 bg-white/70 px-3 py-1 text-xs text-slate-700 backdrop-blur-xl opacity-0 transition group-hover:opacity-100">
           {zoomText}
         </span>
       </button>
     ) : (
-      <div className="flex h-56 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-slate-300 bg-slate-50 text-slate-400">
-        <ImageIcon className="h-10 w-10" />
-        <p className="text-sm">{emptyText}</p>
+      <div className="flex h-56 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-white/75 bg-white/70 text-slate-500 backdrop-blur-xl">
+        <ImageIcon className="h-10 w-10 text-brand-primary/70" />
+        <p className="text-sm text-slate-600">{emptyText}</p>
       </div>
     )}
   </div>

--- a/components/stats/processed-counter.tsx
+++ b/components/stats/processed-counter.tsx
@@ -61,7 +61,7 @@ export const ProcessedCounter = () => {
   );
 
   return (
-    <section className="rounded-card bg-white/90 p-6 shadow-soft">
+    <section className="glass-card p-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p className="text-sm font-medium uppercase tracking-wide text-brand-primary">
@@ -73,15 +73,16 @@ export const ProcessedCounter = () => {
           <StatusMessage error={error} isLoading={isLoading} />
 
         </div>
-        <div className="relative overflow-hidden rounded-2xl bg-slate-900 px-6 py-4 text-white shadow-inner">
-          <div className="pointer-events-none absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent opacity-60">
-            <div className="h-full w-full -translate-x-full animate-shimmer bg-gradient-to-r from-transparent via-white/60 to-transparent" />
+        <div className="relative overflow-hidden rounded-[1.75rem] border border-white/80 bg-gradient-to-br from-white/85 via-sky-100/65 to-slate-50/70 px-6 py-5 text-slate-800 shadow-[0_28px_60px_-34px_rgba(15,23,42,0.26)] backdrop-blur-xl">
+          <div className="pointer-events-none absolute inset-0 opacity-80">
+            <div className="absolute -inset-x-16 top-0 h-full bg-[conic-gradient(from_90deg_at_50%_50%,rgba(148,163,184,0.08)_0deg,rgba(255,255,255,0)_120deg,rgba(125,211,252,0.18)_240deg,rgba(255,255,255,0)_360deg)]" />
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/35 to-transparent" />
           </div>
           <div className="relative z-10 flex flex-col items-end text-right">
-            <span className="text-xs font-medium uppercase tracking-[0.3em] text-white/60">
+            <span className="text-xs font-medium uppercase tracking-[0.3em] text-slate-500">
               {t("metricLabel")}
             </span>
-            <span className="mt-1 font-mono text-4xl font-bold leading-none tabular-nums">
+            <span className="mt-1 font-mono text-4xl font-bold leading-none tabular-nums text-slate-800 drop-shadow-[0_6px_16px_rgba(148,163,184,0.35)]">
               {formattedTotal}
             </span>
           </div>

--- a/components/status/status-banner.tsx
+++ b/components/status/status-banner.tsx
@@ -11,15 +11,29 @@ export const StatusBanner = () => {
   const state = status.state;
   const message = status.message;
 
+  const baseClasses =
+    "relative flex items-center gap-3 overflow-hidden rounded-2xl border px-5 py-4 text-sm backdrop-blur-xl shadow-[0_24px_52px_-32px_rgba(15,23,42,0.28)]";
   const config =
     state === "processing"
-      ? { icon: <Loader2 className="h-5 w-5 animate-spin" />, classes: "border-blue-200 bg-blue-50 text-blue-600", text: message ?? t('processing') }
+      ? {
+          icon: <Loader2 className="h-5 w-5 animate-spin" />,
+          classes: `${baseClasses} border-sky-200/70 bg-sky-100/65 text-slate-800`,
+          text: message ?? t('processing')
+        }
       : state === "success"
-      ? { icon: <CheckCircle2 className="h-5 w-5" />, classes: "border-emerald-200 bg-emerald-50 text-emerald-600", text: message ?? t('success') }
-      : { icon: <AlertCircle className="h-5 w-5" />, classes: "border-rose-200 bg-rose-50 text-rose-600", text: message ?? t('error') };
+      ? {
+          icon: <CheckCircle2 className="h-5 w-5" />,
+          classes: `${baseClasses} border-emerald-200/70 bg-emerald-100/65 text-slate-800`,
+          text: message ?? t('success')
+        }
+      : {
+          icon: <AlertCircle className="h-5 w-5" />,
+          classes: `${baseClasses} border-rose-200/75 bg-rose-100/65 text-slate-800`,
+          text: message ?? t('error')
+        };
 
   return (
-    <div className={`flex items-center gap-3 rounded-2xl border px-4 py-3 text-sm shadow-card ${config.classes}`}>
+    <div className={config.classes}>
       {config.icon}
       <span>{config.text}</span>
     </div>


### PR DESCRIPTION
## Summary
- brighten the global backdrop, glass cards, and action buttons with soft white gradients and enhanced translucency
- refresh the dashboard shell and auth screens to use the new luminous glass background treatments
- tune panels, status surfaces, and incentive CTAs to pastel glass styles with lighter shadows and typography

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d023fee5848325b12079feda31983c