### PR TITLE
Revamp mobile login hero

### DIFF
--- a/components/auth/auth-gate.tsx
+++ b/components/auth/auth-gate.tsx
@@ -27,18 +27,32 @@ export const AuthGate = ({ children }: { children: React.ReactNode }) => {
 
   if (!session) {
     return (
-      <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-6 py-16 text-center">
+      <div className="relative flex min-h-screen flex-col overflow-hidden bg-slate-950 px-6 py-10 text-white">
         <div className="pointer-events-none absolute inset-0 -z-10">
           <div className="absolute inset-0 bg-[radial-gradient(120%_120%_at_0%_0%,rgba(56,189,248,0.22),transparent_55%),radial-gradient(140%_140%_at_90%_-10%,rgba(192,132,252,0.2),transparent_60%),linear-gradient(160deg,rgba(15,23,42,0.95)_0%,rgba(15,23,42,0.62)_48%,rgba(30,41,59,0.85)_100%)]" />
           <div className="absolute inset-0 bg-white/8 mix-blend-soft-light" />
         </div>
-        <div className="glass-card w-full max-w-xl px-10 py-12 text-center text-slate-800">
-          <h1 className="text-3xl font-semibold tracking-tight text-slate-800">Login to continue using EasyPic</h1>
-          <p className="mx-auto mt-3 max-w-md text-sm text-slate-600">
-            Use email magic link or Google one-click login to unlock credit sync, history, and cloud processing.
-          </p>
-          <div className="mt-8 flex justify-center">
-            <SignInButton />
+        <div className="relative z-10 mx-auto flex w-full max-w-md flex-1 flex-col justify-center">
+          <div className="flex flex-col items-center text-center">
+            <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-2xl border-2 border-dashed border-white/50 bg-white/10 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/70">
+              Logo
+            </div>
+            <div className="space-y-2">
+              <p className="text-sm font-medium uppercase tracking-[0.45em] text-white/70">Welcome to</p>
+              <h1 className="text-4xl font-semibold tracking-tight text-white">Snaptosell</h1>
+              <p className="text-base text-white/80">Capture products. Create listings. Convert faster.</p>
+            </div>
+          </div>
+          <div className="mt-10">
+            <div className="glass-card w-full px-6 py-8 text-left text-slate-800 shadow-[0_28px_60px_-40px_rgba(15,23,42,0.9)]">
+              <h2 className="text-lg font-semibold text-slate-900">Sign in to continue</h2>
+              <p className="mt-2 text-sm text-slate-600">
+                Use your email for a magic link or connect instantly with Google to sync credits, history, and cloud processing.
+              </p>
+              <div className="mt-8">
+                <SignInButton />
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/components/auth/sign-in-button.tsx
+++ b/components/auth/sign-in-button.tsx
@@ -61,18 +61,18 @@ export const SignInButton = () => {
     <div className="w-full max-w-sm space-y-6 text-left text-slate-800">
       <form onSubmit={handleEmail} className="space-y-3">
         <label className="block text-sm font-medium tracking-wide text-slate-600">Email Login</label>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <input
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
-            className="flex-1 rounded-full border border-white/60 bg-white/60 px-5 py-3 text-sm text-slate-800 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] backdrop-blur-xl placeholder:text-slate-500 focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200/60"
-            placeholder="you@example.com"
+            className="w-full flex-1 rounded-full border border-white/60 bg-white/70 px-5 py-3 text-sm text-slate-800 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] backdrop-blur-xl placeholder:text-slate-500 focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200/60"
+            placeholder="填写你的邮箱"
             required
           />
           <button
             type="submit"
-            className="flex items-center gap-2 rounded-full border border-white/60 bg-gradient-to-r from-sky-500/80 to-sky-400/70 px-5 py-3 text-sm font-semibold text-white shadow-[0_20px_40px_-28px_rgba(37,99,235,0.85)] transition hover:-translate-y-0.5 hover:shadow-[0_24px_48px_-26px_rgba(37,99,235,0.9)] disabled:cursor-not-allowed disabled:opacity-70"
+            className="flex w-full items-center justify-center gap-2 rounded-full border border-sky-300/60 bg-gradient-to-r from-sky-500 to-cyan-400 px-5 py-3 text-sm font-semibold text-white shadow-[0_18px_38px_-26px_rgba(14,165,233,0.85)] transition hover:-translate-y-0.5 hover:shadow-[0_22px_44px_-24px_rgba(14,165,233,0.9)] disabled:cursor-not-allowed disabled:opacity-70 sm:w-auto"
             disabled={status !== "idle"}
           >
             <Mail className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- redesign the unauthenticated auth gate to feel like a mobile-first Snaptosell landing experience
- highlight the Snaptosell name with a modern tagline and provide a reserved logo drop zone
- encapsulate the existing sign-in form within an elevated glass card for better visual hierarchy
- tailor the email capture and send action for mobile with a localized placeholder and full-width gradient CTA

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d050f57c588325b907690660785a62