### PR TITLE
Fix locale-aware redirects after authentication

### DIFF
--- a/app/api/purchase/start/route.ts
+++ b/app/api/purchase/start/route.ts
@@ -1,5 +1,6 @@
 import Stripe from "stripe";
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 import { supabaseServer } from "@/lib/supabase-server";
 
 const stripeKey = process.env.STRIPE_SECRET_KEY ?? "";
@@ -20,6 +21,9 @@ export async function POST() {
   }
 
   try {
+    const locale = cookies().get("NEXT_LOCALE")?.value ?? "en";
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+
     const session = await stripe.checkout.sessions.create({
       mode: "payment",
       customer_email: user.email ?? undefined,
@@ -30,8 +34,8 @@ export async function POST() {
         }
       ],
       metadata: { user_id: user.id },
-      success_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard?purchase=success`,
-      cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard?purchase=cancel`
+      success_url: `${baseUrl}/${locale}/dashboard?purchase=success`,
+      cancel_url: `${baseUrl}/${locale}/dashboard?purchase=cancel`
     });
 
     return NextResponse.json({ url: session.url });

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -4,10 +4,12 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@/types/supabase";
 
 export async function GET(request: Request) {
+  const cookieStore = cookies();
+  const locale = cookieStore.get("NEXT_LOCALE")?.value ?? "en";
   const requestUrl = new URL(request.url);
   const code = requestUrl.searchParams.get("code");
   const errorDescription = requestUrl.searchParams.get("error_description");
-  const redirectTo = requestUrl.searchParams.get("redirect_to") ?? `${process.env.NEXT_PUBLIC_APP_URL}/dashboard`;
+  const redirectTo = requestUrl.searchParams.get("redirect_to") ?? `${process.env.NEXT_PUBLIC_APP_URL}/${locale}/dashboard`;
 
   if (!code) {
     const fallback = errorDescription ?? "auth";


### PR DESCRIPTION
## Summary
- ensure the Supabase auth callback falls back to the locale-specific dashboard URL
- update Stripe checkout redirect URLs to respect the active locale cookie

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d056246fd88325a1ccd7f9aa8c1383