### PR TITLE
Add marketing banner to auth and dashboard views

### DIFF
--- a/components/auth/auth-gate.tsx
+++ b/components/auth/auth-gate.tsx
@@ -4,6 +4,7 @@ import { useSessionContext } from "@supabase/auth-helpers-react";
 import { useEffect, useState } from "react";
 import logoImage from "@/lib/logo.png";
 import { SignInButton } from "@/components/auth/sign-in-button";
+import { ContactPromoBanner } from "@/components/marketing/contact-promo-banner";
 
 export const AuthGate = ({ children }: { children: React.ReactNode }) => {
   const { session, isLoading } = useSessionContext();
@@ -33,6 +34,9 @@ export const AuthGate = ({ children }: { children: React.ReactNode }) => {
         <div className="pointer-events-none absolute inset-0 -z-10">
           <div className="absolute inset-0 bg-[radial-gradient(120%_120%_at_0%_0%,rgba(56,189,248,0.22),transparent_55%),radial-gradient(140%_140%_at_90%_-10%,rgba(192,132,252,0.2),transparent_60%),linear-gradient(160deg,rgba(15,23,42,0.95)_0%,rgba(15,23,42,0.62)_48%,rgba(30,41,59,0.85)_100%)]" />
           <div className="absolute inset-0 bg-white/8 mix-blend-soft-light" />
+        </div>
+        <div className="relative z-20 mx-auto w-full max-w-md pt-4">
+          <ContactPromoBanner className="backdrop-blur-xl" />
         </div>
         <div className="relative z-10 mx-auto flex w-full max-w-md flex-1 flex-col justify-center">
           <div className="flex flex-col items-center text-center">

--- a/components/layout/dashboard-layout.tsx
+++ b/components/layout/dashboard-layout.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ContactPromoBanner } from "@/components/marketing/contact-promo-banner";
+
 export const DashboardLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="relative min-h-screen overflow-hidden">
@@ -7,7 +9,12 @@ export const DashboardLayout = ({ children }: { children: React.ReactNode }) => 
         <div className="absolute inset-0 bg-[radial-gradient(130%_130%_at_50%_-15%,rgba(255,255,255,0.95)_0%,rgba(255,255,255,0.75)_45%,rgba(226,232,240,0.25)_80%,transparent_100%),radial-gradient(140%_140%_at_100%_10%,rgba(221,214,254,0.45),transparent_75%),radial-gradient(140%_140%_at_0%_100%,rgba(191,219,254,0.42),transparent_78%)]" />
         <div className="absolute inset-0 bg-white/60 mix-blend-screen" />
       </div>
-      <div className="mx-auto w-full max-w-6xl pb-24 pt-safe-top">{children}</div>
+      <div className="mx-auto w-full max-w-6xl pb-24 pt-safe-top">
+        <div className="px-4 pt-6 sm:pt-8">
+          <ContactPromoBanner tone="light" className="mx-auto max-w-3xl" />
+        </div>
+        {children}
+      </div>
     </div>
   );
 };

--- a/components/marketing/contact-promo-banner.tsx
+++ b/components/marketing/contact-promo-banner.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import classNames from "classnames";
+import { ArrowUpRight, Sparkles } from "lucide-react";
+
+const toneStyles = {
+  dark: {
+    container:
+      "border-white/20 bg-white/10 text-white shadow-[0_18px_50px_-28px_rgba(15,23,42,0.95)] hover:border-white/35 hover:bg-white/20 focus-visible:ring-white/60 focus-visible:ring-offset-slate-950",
+    icon: "bg-white/15 text-white/90",
+    accent: "text-sky-200",
+  },
+  light: {
+    container:
+      "border-slate-200/70 bg-white/90 text-slate-800 shadow-[0_18px_45px_-30px_rgba(15,23,42,0.55)] hover:border-slate-300 hover:bg-white focus-visible:ring-slate-400 focus-visible:ring-offset-white",
+    icon: "bg-slate-900 text-white",
+    accent: "text-slate-500",
+  },
+};
+
+type ContactPromoBannerProps = {
+  tone?: keyof typeof toneStyles;
+  className?: string;
+};
+
+export const ContactPromoBanner = ({
+  tone = "dark",
+  className,
+}: ContactPromoBannerProps) => {
+  const styles = toneStyles[tone];
+  const eyebrowTextClass = tone === "light" ? "text-slate-500" : "text-white/70";
+
+  return (
+    <a
+      href="mailto:digtialpulse@gmail.com"
+      className={classNames(
+        "group relative flex items-center justify-between gap-4 rounded-full border px-5 py-3 text-sm font-medium backdrop-blur transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+        styles.container,
+        className,
+      )}
+      aria-label="Contact Digital Pulse for bulk image editing"
+    >
+      <span className="flex items-center gap-3">
+        <span
+          className={classNames(
+            "flex h-9 w-9 items-center justify-center rounded-full shadow-[0_12px_32px_-22px_rgba(15,23,42,0.8)] transition",
+            styles.icon,
+            tone === "light" ? "group-hover:bg-slate-800" : "group-hover:bg-white/20",
+          )}
+        >
+          <Sparkles className="h-4 w-4" />
+        </span>
+        <span className="flex flex-col text-left leading-tight">
+          <span className={classNames("text-xs uppercase tracking-[0.22em]", eyebrowTextClass)}>
+            Need bulk edits?
+          </span>
+          <span className="text-sm font-semibold">
+            Any product visuals, ready in batches.
+          </span>
+        </span>
+      </span>
+      <span className={classNames("flex items-center gap-1 text-xs font-semibold", styles.accent)}>
+        digtialpulse@gmail.com
+        <ArrowUpRight className="h-4 w-4 transition group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+      </span>
+    </a>
+  );
+};


### PR DESCRIPTION
## Summary
- add a reusable contact promo banner component for the bulk image editing offer
- surface the banner on the sign-in screen and at the top of the dashboard layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0dcc1cb00832596f3306c9b694757