### PR TITLE
Update step guidance copy to English

### DIFF
--- a/components/actions/action-grid.tsx
+++ b/components/actions/action-grid.tsx
@@ -46,6 +46,9 @@ export const ActionGrid = () => {
 
       <section className="toolbar">
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-6">
+          <p className="col-span-2 text-xs font-medium text-slate-500 sm:col-span-6">
+            {t('step1Label')}
+          </p>
           <button
             className="action-button action-button--primary"
             onClick={triggerCamera}
@@ -58,6 +61,9 @@ export const ActionGrid = () => {
             <ImagePlus className="h-6 w-6 text-brand-primary" />
             <span>{t('fromAlbum')}</span>
           </button>
+          <p className="col-span-2 mt-2 text-xs font-medium text-slate-500 sm:col-span-6">
+            {t('step2Label')}
+          </p>
           <button
             className="action-button action-button--emerald"
             onClick={() => startJob("enhance", supabase, { costCredits: 0 })}
@@ -74,6 +80,9 @@ export const ActionGrid = () => {
             {isSubmitting ? <Loader2 className="h-6 w-6 animate-spin" /> : <Package className="h-6 w-6" />}
             <span>{isSubmitting ? t('processing') : t('generateProductPhoto')}</span>
           </button>
+          <p className="col-span-2 mt-2 text-xs font-medium text-slate-500 sm:col-span-6">
+            {t('step3Label')}
+          </p>
           <button
             className="action-button action-button--rose"
             onClick={() => {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,5 +1,8 @@
 {
   "ActionGrid": {
+    "step1Label": "Step 1 · Choose your photo source",
+    "step2Label": "Step 2 · Pick a tool",
+    "step3Label": "Step 3 · Share or download",
     "takePhoto": "Take Photo",
     "fromAlbum": "From Album",
     "enhanceQuality": "Enhance Quality",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1,5 +1,8 @@
 {
   "ActionGrid": {
+    "step1Label": "Step 1 · Choose your photo source",
+    "step2Label": "Step 2 · Pick a tool",
+    "step3Label": "Step 3 · Share or download",
     "takePhoto": "拍摄商品图",
     "fromAlbum": "从相册选择",
     "enhanceQuality": "增强画质",


### PR DESCRIPTION
## Summary
- update action grid helper labels with concise English-only copy
- mirror the new English helper text across both locale files

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0e5ad90dc832599667ca6051c95d8